### PR TITLE
Fix NullPointerException when providing homepage and no sources

### DIFF
--- a/src/main/java/com/extracraftx/minecraft/templatemakerfabric/TemplateMakerFabric.java
+++ b/src/main/java/com/extracraftx/minecraft/templatemakerfabric/TemplateMakerFabric.java
@@ -86,7 +86,7 @@ public class TemplateMakerFabric {
             obj.contact.sources = mod.getSources().toString();
         }
         if (mod.getHomepage() != null) {
-            obj.contact.homepage = mod.getSources().toString();
+            obj.contact.homepage = mod.getHomepage().toString();
         }
         obj.license = mod.getLicense().value;
         obj.icon = "assets/" + mod.getModId() + "/icon.png";


### PR DESCRIPTION
Fixed a little copy/paste mistake leading to NullPointerException:

```
java.lang.NullPointerException
        at com.extracraftx.minecraft.templatemakerfabric.TemplateMakerFabric.outputFabricModJson(TemplateMakerFabric.java:89)
        at com.extracraftx.minecraft.templatemakerfabric.TemplateMakerFabric.outputMod(TemplateMakerFabric.java:69)
        at com.extracraftx.minecraft.generatorfabricmod.GeneratorFabricMod.main(GeneratorFabricMod.java:214)
```