### PR TITLE
Migrate from CurseForge to Modrinth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build
 .vscode
 .settings
 
+# Ignore intellij files
+.idea
+
 # Ignore run binaries
 bin
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = 'TemplateMakerFabric'
-version = '0.4.0'
+version = '0.4.1'
 group = 'com.extracraftx.minecraft'
 
 repositories {
@@ -40,10 +40,10 @@ publishing{
     repositories{
         mavenLocal()
 		maven{
-			url = extracraftxMaven
+			url = System.getenv().getOrDefault('extracraftxMaven', "NO_MAVEN")
 			credentials {
-				username = extracraftxMavenUsername
-				password = extracraftxMavenPassword
+				username = System.getenv().getOrDefault('extracraftxMavenUsername', "NO_USERNAME")
+				password = System.getenv().getOrDefault('extracraftxMavenPassword', "NO_PASSWORD")
 			}
 		}
     }

--- a/src/main/java/com/extracraftx/minecraft/templatemakerfabric/data/DataProvider.java
+++ b/src/main/java/com/extracraftx/minecraft/templatemakerfabric/data/DataProvider.java
@@ -118,12 +118,12 @@ public class DataProvider {
     public ArrayList<FabricApiVersion> getFabricApiVersions() throws IOException{
         if(apiVersions != null)
             return apiVersions;
-        JsonArray apiVersionsData = jsonFromUrl("https://addons-ecs.forgesvc.net/api/v2/addon/306612/files").getAsJsonArray();
+        JsonArray apiVersionsData = jsonFromUrl("https://api.modrinth.com/v2/project/P7dR8mSH/version").getAsJsonArray();
         ArrayList<FabricApiVersion> apiVersions = new ArrayList<>();
         for(int i = 0; i < apiVersionsData.size(); i++){
             JsonObject versionData = apiVersionsData.get(i).getAsJsonObject();
-            String name = versionData.get("displayName").getAsString();
-            String fileName = versionData.get("fileName").getAsString();
+            String name = versionData.get("name").getAsString();
+            String fileName = versionData.get("files").getAsJsonArray().get(0).getAsJsonObject().get("filename").getAsString();
             try{
                 apiVersions.add(new FabricApiVersion(name, fileName));
             }catch(IllegalArgumentException e){}


### PR DESCRIPTION
CurseForge's old API is defunct and Modrinth is more Fabric-focused anyway
Library's usage in [MinecraftDev](https://github.com/minecraft-dev/minecraftdev):  
![java_vOSxg6gTFw](https://user-images.githubusercontent.com/5004171/169924824-34df4ed2-29a2-4769-b0d7-768fe0c443c8.png)